### PR TITLE
fix the deserialization of length and keys

### DIFF
--- a/tools/folder2lmdb.py
+++ b/tools/folder2lmdb.py
@@ -28,8 +28,8 @@ class ImageFolderLMDB(data.Dataset):
                              readahead=False, meminit=False)
         with self.env.begin(write=False) as txn:
             # self.length = txn.stat()['entries'] - 1
-            self.length = txn.get(b'__len__')
-            self.keys = msgpack.loads(txn.get(b'__keys__'))
+            self.length =pa.deserialize(txn.get(b'__len__'))
+            self.keys= pa.deserialize(txn.get(b'__keys__'))
 
         self.transform = transform
         self.target_transform = target_transform


### PR DESCRIPTION
There an error in the old version of deserialization of length and keys because pyarrow was used to serialize both of length and keys, and the length was not deserialized besdies  the keys were deserialized with msgpack not pyarrow.