### PR TITLE
Replaced pyarrow - Windows support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,24 +1,16 @@
 import argparse
-import os
-import random
 import shutil
 import time
-import warnings
 import os.path as osp
-
 import torch
 import torch.nn as nn
 import torch.nn.parallel
-import torch.backends.cudnn as cudnn
-import torch.distributed as dist
 import torch.optim
 import torch.utils.data
 import torch.utils.data.distributed
 import torchvision
 import torchvision.transforms as transforms
-import torchvision.datasets as datasets
 import torchvision.models as models
-
 from tools.folder2lmdb import ImageFolderLMDB
 
 model_names = sorted(name for name in models.__dict__

--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ import argparse
 import shutil
 import time
 import random
-import os.path as osp
 import torch
 import torch.nn as nn
 import torch.nn.parallel
@@ -11,13 +10,9 @@ import torch.backends.cudnn as cudnn
 import torch.distributed as dist
 import torch.utils.data
 import torch.utils.data.distributed
-import torchvision
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
-from tools.folder2lmdb import ImageFolderLMDB
-import lmdb
-import pickle
 import warnings
 import os
 

--- a/main.py
+++ b/main.py
@@ -13,9 +13,12 @@ import torch.distributed as dist
 import torch.optim
 import torch.utils.data
 import torch.utils.data.distributed
+import torchvision
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
+
+from tools.folder2lmdb import ImageFolderLMDB
 
 model_names = sorted(name for name in models.__dict__
     if name.islower() and not name.startswith("__")
@@ -64,136 +67,58 @@ parser.add_argument('--gpu', default=None, type=int,
 
 best_acc1 = 0
 
+DBS = ['lmdb', 'imagefolder']
+PRINT_STATUS = True
 
 def main():
-    global args, best_acc1
-    args = parser.parse_args()
-
-    if args.seed is not None:
-        random.seed(args.seed)
-        torch.manual_seed(args.seed)
-        cudnn.deterministic = True
-        warnings.warn('You have chosen to seed training. '
-                      'This will turn on the CUDNN deterministic setting, '
-                      'which can slow down your training considerably! '
-                      'You may see unexpected behavior when restarting '
-                      'from checkpoints.')
-
-    if args.gpu is not None:
-        warnings.warn('You have chosen a specific GPU. This will completely '
-                      'disable data parallelism.')
-
-    args.distributed = args.world_size > 1
-
-    if args.distributed:
-        dist.init_process_group(backend=args.dist_backend, init_method=args.dist_url,
-                                world_size=args.world_size)
-
-    # create model
-    if args.pretrained:
-        print("=> using pre-trained model '{}'".format(args.arch))
-        model = models.__dict__[args.arch](pretrained=True)
-    else:
-        print("=> creating model '{}'".format(args.arch))
-        model = models.__dict__[args.arch]()
-
-    if args.gpu is not None:
-        model = model.cuda(args.gpu)
-    elif args.distributed:
-        model.cuda()
-        model = torch.nn.parallel.DistributedDataParallel(model)
-    else:
-        if args.arch.startswith('alexnet') or args.arch.startswith('vgg'):
-            model.features = torch.nn.DataParallel(model.features)
-            model.cuda()
-        else:
-            model = torch.nn.DataParallel(model).cuda()
-
+    model = models.__dict__['resnet18'](pretrained=True)
+    model_params = model.parameters()
+    data_dir = "C:\\Users\\cml\\Downloads\\cats_vs_dogs\\train"
+    data_db = "C:\\Users\\cml\\Downloads\\cats_vs_dogs\\train.lmdb"
+    
+    # send model to gpu
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")   
+    model = model.to(device)
+    
     # define loss function (criterion) and optimizer
-    criterion = nn.CrossEntropyLoss().cuda(args.gpu)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model_params, lr=0.01)
 
-    optimizer = torch.optim.SGD(model.parameters(), args.lr,
-                                momentum=args.momentum,
-                                weight_decay=args.weight_decay)
-
-    # optionally resume from a checkpoint
-    if args.resume:
-        if os.path.isfile(args.resume):
-            print("=> loading checkpoint '{}'".format(args.resume))
-            checkpoint = torch.load(args.resume)
-            args.start_epoch = checkpoint['epoch']
-            best_acc1 = checkpoint['best_acc1']
-            model.load_state_dict(checkpoint['state_dict'])
-            optimizer.load_state_dict(checkpoint['optimizer'])
-            print("=> loaded checkpoint '{}' (epoch {})"
-                  .format(args.resume, checkpoint['epoch']))
-        else:
-            print("=> no checkpoint found at '{}'".format(args.resume))
-
-    cudnn.benchmark = True
-
-    # Data loading code
-    traindir = os.path.join(args.data, 'train')
-    valdir = os.path.join(args.data, 'val')
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                      std=[0.229, 0.224, 0.225])
 
-    train_dataset = datasets.ImageFolder(
-        traindir,
-        transforms.Compose([
-            transforms.RandomResizedCrop(224),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            normalize,
-        ]))
-
-    if args.distributed:
-        train_sampler = torch.utils.data.distributed.DistributedSampler(train_dataset)
-    else:
-        train_sampler = None
-
-    train_loader = torch.utils.data.DataLoader(
-        train_dataset, batch_size=args.batch_size, shuffle=(train_sampler is None),
-        num_workers=args.workers, pin_memory=True, sampler=train_sampler)
-
-    val_loader = torch.utils.data.DataLoader(
-        datasets.ImageFolder(valdir, transforms.Compose([
-            transforms.Resize(256),
-            transforms.CenterCrop(224),
-            transforms.ToTensor(),
-            normalize,
-        ])),
-        batch_size=args.batch_size, shuffle=False,
-        num_workers=args.workers, pin_memory=True)
-
-    if args.evaluate:
-        validate(val_loader, model, criterion)
-        return
-
-    for epoch in range(args.start_epoch, args.epochs):
-        if args.distributed:
-            train_sampler.set_epoch(epoch)
-        adjust_learning_rate(optimizer, epoch)
-
-        # train for one epoch
-        train(train_loader, model, criterion, optimizer, epoch)
-
-        # evaluate on validation set
-        acc1 = validate(val_loader, model, criterion)
-
-        # remember best acc@1 and save checkpoint
-        is_best = acc1 > best_acc1
-        best_acc1 = max(acc1, best_acc1)
-        save_checkpoint({
-            'epoch': epoch + 1,
-            'arch': args.arch,
-            'state_dict': model.state_dict(),
-            'best_acc1': best_acc1,
-            'optimizer' : optimizer.state_dict(),
-        }, is_best)
-
-
-def train(train_loader, model, criterion, optimizer, epoch):
+    for dataset_type in DBS:
+        if dataset_type == 'lmdb':
+            train_dataset = ImageFolderLMDB(
+                data_db,
+                transforms.Compose([
+                    transforms.RandomResizedCrop(64),
+                    transforms.RandomHorizontalFlip(),
+                    transforms.ToTensor(),
+                    normalize,
+                ]))
+        else:
+            train_dataset = torchvision.datasets.ImageFolder(
+                data_dir,
+                transforms.Compose([
+                    transforms.RandomResizedCrop(64),
+                    transforms.RandomHorizontalFlip(),
+                    transforms.ToTensor(),
+                    normalize,
+                ]))
+        
+        train_loader = torch.utils.data.DataLoader(
+            train_dataset, batch_size=128, shuffle=True,
+            num_workers=4, pin_memory=True)
+    
+        batch_time, data_time = train(train_loader, model, criterion, optimizer, device)
+        print(f"Timings for {dataset_type}: ")
+        print(f"Avg data time: {data_time.avg}")
+        print(f"Avg batch time: {batch_time.avg}")
+        print(f"Total data time: {data_time.sum}")
+        print(f"Total batch time: {batch_time.sum}\n")
+    
+def train(train_loader, model, criterion, optimizer, device, epoch=0):
     batch_time = AverageMeter()
     data_time = AverageMeter()
     losses = AverageMeter()
@@ -207,14 +132,14 @@ def train(train_loader, model, criterion, optimizer, epoch):
     for i, (input, target) in enumerate(train_loader):
         # measure data loading time
         data_time.update(time.time() - end)
-
-        if args.gpu is not None:
-            input = input.cuda(args.gpu, non_blocking=True)
-        target = target.cuda(args.gpu, non_blocking=True)
+        
+        # send input + target to gpu
+        input = input.to(device)
+        target = target.to(device)
 
         # compute output
         output = model(input)
-        loss = criterion(output, target)
+        loss = criterion(output, target.squeeze())
 
         # measure accuracy and record loss
         acc1, acc5 = accuracy(output, target, topk=(1, 5))
@@ -231,67 +156,23 @@ def train(train_loader, model, criterion, optimizer, epoch):
         batch_time.update(time.time() - end)
         end = time.time()
 
-        if i % args.print_freq == 0:
-            print('Epoch: [{0}][{1}/{2}]\t'
-                  'Time {batch_time.val:.3f} ({batch_time.avg:.3f})\t'
-                  'Data {data_time.val:.3f} ({data_time.avg:.3f})\t'
-                  'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                  'Acc@1 {top1.val:.3f} ({top1.avg:.3f})\t'
-                  'Acc@5 {top5.val:.3f} ({top5.avg:.3f})'.format(
-                   epoch, i, len(train_loader), batch_time=batch_time,
-                   data_time=data_time, loss=losses, top1=top1, top5=top5))
-
-
-def validate(val_loader, model, criterion):
-    batch_time = AverageMeter()
-    losses = AverageMeter()
-    top1 = AverageMeter()
-    top5 = AverageMeter()
-
-    # switch to evaluate mode
-    model.eval()
-
-    with torch.no_grad():
-        end = time.time()
-        for i, (input, target) in enumerate(val_loader):
-            if args.gpu is not None:
-                input = input.cuda(args.gpu, non_blocking=True)
-            target = target.cuda(args.gpu, non_blocking=True)
-
-            # compute output
-            output = model(input)
-            loss = criterion(output, target)
-
-            # measure accuracy and record loss
-            acc1, acc5 = accuracy(output, target, topk=(1, 5))
-            losses.update(loss.item(), input.size(0))
-            top1.update(acc1[0], input.size(0))
-            top5.update(acc5[0], input.size(0))
-
-            # measure elapsed time
-            batch_time.update(time.time() - end)
-            end = time.time()
-
-            if i % args.print_freq == 0:
-                print('Test: [{0}/{1}]\t'
-                      'Time {batch_time.val:.3f} ({batch_time.avg:.3f})\t'
-                      'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                      'Acc@1 {top1.val:.3f} ({top1.avg:.3f})\t'
-                      'Acc@5 {top5.val:.3f} ({top5.avg:.3f})'.format(
-                       i, len(val_loader), batch_time=batch_time, loss=losses,
-                       top1=top1, top5=top5))
-
-        print(' * Acc@1 {top1.avg:.3f} Acc@5 {top5.avg:.3f}'
-              .format(top1=top1, top5=top5))
-
-    return top1.avg
-
+        if i % 10 == 0:
+            if PRINT_STATUS:
+                print('Epoch: [{0}][{1}/{2}]\t'
+                    'Time {batch_time.val:.3f} ({batch_time.avg:.3f})\t'
+                    'Data {data_time.val:.3f} ({data_time.avg:.3f})\t'
+                    'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
+                    'Acc@1 {top1.val:.3f} ({top1.avg:.3f})\t'
+                    'Acc@5 {top5.val:.3f} ({top5.avg:.3f})'.format(
+                    epoch, i, len(train_loader), batch_time=batch_time,
+                    data_time=data_time, loss=losses, top1=top1, top5=top5))
+            
+    return batch_time, data_time
 
 def save_checkpoint(state, is_best, filename='checkpoint.pth.tar'):
     torch.save(state, filename)
     if is_best:
         shutil.copyfile(filename, 'model_best.pth.tar')
-
 
 class AverageMeter(object):
     """Computes and stores the average and current value"""
@@ -310,16 +191,14 @@ class AverageMeter(object):
         self.count += n
         self.avg = self.sum / self.count
 
-
 def adjust_learning_rate(optimizer, epoch):
     """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
-    lr = args.lr * (0.1 ** (epoch // 30))
+    lr = 0.01 * (0.1 ** (epoch // 30))
     for param_group in optimizer.param_groups:
         param_group['lr'] = lr
 
-
 def accuracy(output, target, topk=(1,)):
-    """Computes the accuracy over the k top predictions for the specified values of k"""
+    """Computes the accuracy over the k top predictions for the  ecified values of k"""
     with torch.no_grad():
         maxk = max(topk)
         batch_size = target.size(0)
@@ -330,10 +209,9 @@ def accuracy(output, target, topk=(1,)):
 
         res = []
         for k in topk:
-            correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)
+            correct_k = correct[:k].reshape(-1).float().sum(0, keepdim=True)
             res.append(correct_k.mul_(100.0 / batch_size))
         return res
-
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -197,7 +197,7 @@ def adjust_learning_rate(optimizer, epoch):
         param_group['lr'] = lr
 
 def accuracy(output, target, topk=(1,)):
-    """Computes the accuracy over the k top predictions for the  ecified values of k"""
+    """Computes the accuracy over the k top predictions for the specified values of k"""
     with torch.no_grad():
         maxk = max(topk)
         batch_size = target.size(0)

--- a/main.py
+++ b/main.py
@@ -170,6 +170,10 @@ def main():
         batch_size=args.batch_size, shuffle=False,
         num_workers=args.workers, pin_memory=True)
     
+    if args.evaluate:
+        validate(val_loader, model, criterion)
+        return
+    
     for epoch in range(args.start_epoch, args.epochs):
         if args.distributed:
             train_sampler.set_epoch(epoch)

--- a/main.py
+++ b/main.py
@@ -152,8 +152,8 @@ def main():
         train_sampler = None
     
     train_loader = torch.utils.data.DataLoader(
-    train_dataset, batch_size=args.batch_size, shuffle=(train_sampler is None),
-    num_workers=args.workers, pin_memory=True, sampler=train_sampler)
+        train_dataset, batch_size=args.batch_size, shuffle=(train_sampler is None),
+        num_workers=args.workers, pin_memory=True, sampler=train_sampler)
 
     val_loader = torch.utils.data.DataLoader(
         datasets.ImageFolder(valdir, transforms.Compose([

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import time
 import warnings
+import os.path as osp
 
 import torch
 import torch.nn as nn
@@ -75,7 +76,8 @@ def main():
     model_params = model.parameters()
     data_dir = "C:\\Users\\cml\\Downloads\\cats_vs_dogs\\train"
     data_db = "C:\\Users\\cml\\Downloads\\cats_vs_dogs\\train.lmdb"
-    
+    directory = "C:\\Users\\cml\\Downloads\\cats_vs_dogs"
+        
     # send model to gpu
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")   
     model = model.to(device)
@@ -86,11 +88,16 @@ def main():
 
     normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                      std=[0.229, 0.224, 0.225])
+    
+    # get the size of the db
+    with open(osp.join(directory, 'LMDB_SIZE'), 'r') as fd:
+        data_size = int(fd.read())
 
     for dataset_type in DBS:
         if dataset_type == 'lmdb':
             train_dataset = ImageFolderLMDB(
                 data_db,
+                data_size,
                 transforms.Compose([
                     transforms.RandomResizedCrop(64),
                     transforms.RandomHorizontalFlip(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 torch
 torchvision
 lmdb
-pyarrow

--- a/tools/folder2lmdb.py
+++ b/tools/folder2lmdb.py
@@ -1,21 +1,13 @@
 import os
 import os.path as osp
-import os, sys
-import os.path as osp
-from PIL import Image
-
 import six
 import lmdb
 import pickle
 import msgpack
-import pyarrow as pa
-
-import torch
 import torch.utils.data as data
+from PIL import Image
 from torch.utils.data import DataLoader
-from torchvision.transforms import transforms
 from torchvision.datasets import ImageFolder
-from torchvision import transforms, datasets
 
 class ImageFolderLMDB(data.Dataset):
     def __init__(self, db_path, db_size, transform=None, target_transform=None):

--- a/tools/folder2lmdb.py
+++ b/tools/folder2lmdb.py
@@ -10,9 +10,8 @@ from torch.utils.data import DataLoader
 from torchvision.datasets import ImageFolder
 
 class ImageFolderLMDB(data.Dataset):
-    def __init__(self, db_path, lengeth, transform=None, target_transform=None):
+    def __init__(self, db_path, transform=None, target_transform=None):
         self.db_path = db_path
-        self.length = lengeth
         self.transform = transform
         self.target_transform = target_transform
         
@@ -122,7 +121,7 @@ def dumps_pickle(obj):
     """
     return pickle.dumps(obj)
 
-def folder2lmdb(dpath, name="train_images", write_frequency=5000, num_workers=0):
+def folder2lmdb(dpath, name="train", write_frequency=5000, num_workers=0):
     directory = osp.expanduser(osp.join(dpath, name))
     print("Loading dataset from %s" % directory)
     dataset = ImageFolder(directory, loader=raw_reader)

--- a/tools/folder2lmdb.py
+++ b/tools/folder2lmdb.py
@@ -15,14 +15,19 @@ class ImageFolderLMDB(data.Dataset):
         self.length = lengeth
         self.transform = transform
         self.target_transform = target_transform
+        
+        env = lmdb.open(self.db_path, subdir=osp.isdir(self.db_path),
+                readonly=True, lock=False,
+                readahead=False, meminit=False)
+        with env.begin(write=False) as txn:
+            self.length = pickle.loads(txn.get(b'__len__'))
+            self.keys = pickle.loads(txn.get(b'__keys__'))
 
     def open_lmdb(self):
          self.env = lmdb.open(self.db_path, subdir=osp.isdir(self.db_path),
                               readonly=True, lock=False,
                               readahead=False, meminit=False)
          self.txn = self.env.begin(write=False, buffers=True)
-         self.length = pickle.loads(self.txn.get(b'__len__'))
-         self.keys = pickle.loads(self.txn.get(b'__keys__'))
 
     def __getitem__(self, index):
         if not hasattr(self, 'txn'):


### PR DESCRIPTION
Made a few changes to the code:

- Removed pyarrow since it is deprecated. Replaced with pickle.
- Took out the lambda collate fn since it's not supported on Windows from what I can tell.
- Added open_lmdb() to not open db in __init__. This fixes this issue: https://github.com/pytorch/vision/issues/689
- Set some vars to default values, num_workers and procs, to improve compatibility.